### PR TITLE
Prevent Accumulation of Event Cards

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -66,6 +66,7 @@ const searchCity = async () => {
     let eventDiv = document.getElementById("events")
     if (events) {
         
+      eventDiv.innerHTML = '';
         events.forEach(item => {
             console.log("item:", item)
             let endObj = item.dates.end ? item.dates.end : ''


### PR DESCRIPTION
- HTML element "eventDiv" was not being cleared before appending events from the next search. The element is now being cleared.